### PR TITLE
String.Format missing parameters in Message property.

### DIFF
--- a/Gitea.API/v1/UnexpectedResponseException.cs
+++ b/Gitea.API/v1/UnexpectedResponseException.cs
@@ -52,7 +52,7 @@ namespace Gitea.API.v1
         /// <inheritdoc />
         public override string Message
         {
-            get { return string.Format("Unexpected response: [{0}] '{1}'"); }
+            get { return $"Unexpected response: [{Code}] '{Status}'"; }
         }
 
         /// <summary>


### PR DESCRIPTION
Here is a small bug fix.